### PR TITLE
✨ Feature: 로그아웃 API

### DIFF
--- a/src/main/java/potenday/app/api/AuthController.java
+++ b/src/main/java/potenday/app/api/AuthController.java
@@ -10,10 +10,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import potenday.app.api.auth.AccessRefreshTokenResponse;
 import potenday.app.api.auth.AccessTokenResponse;
+import potenday.app.api.auth.LogoutTokenRequest;
 import potenday.app.api.auth.OAuthUriResponse;
 import potenday.app.api.auth.TokenRequest;
 import potenday.app.api.common.ApiResponse;
 import potenday.app.domain.AppTokenService;
+import potenday.app.domain.auth.AppUser;
+import potenday.app.domain.auth.AuthenticationPrincipal;
 import potenday.app.domain.auth.OAuthAuthenticationService;
 import potenday.app.oauth.OAuthClient;
 import potenday.app.oauth.OAuthMember;
@@ -64,5 +67,14 @@ public class AuthController {
   ) {
     String accessToken = appTokenService.reIssueAccessToken(refreshToken);
     return ApiResponse.success(AccessTokenResponse.from(accessToken));
+  }
+
+  @PostMapping("/auth/logout")
+  public ApiResponse<Void> removeRefreshToken(
+      @AuthenticationPrincipal AppUser appUser,
+      @Valid @RequestBody LogoutTokenRequest logoutTokenRequest
+  ) {
+    appTokenService.removeRefreshToken(appUser, logoutTokenRequest);
+    return ApiResponse.success();
   }
 }

--- a/src/main/java/potenday/app/api/auth/LogoutTokenRequest.java
+++ b/src/main/java/potenday/app/api/auth/LogoutTokenRequest.java
@@ -1,0 +1,17 @@
+package potenday.app.api.auth;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LogoutTokenRequest {
+
+  @NotNull(message = "L005")
+  @NotEmpty(message = "L005")
+  private String refreshToken;
+}

--- a/src/main/java/potenday/app/domain/AppTokenService.java
+++ b/src/main/java/potenday/app/domain/AppTokenService.java
@@ -1,12 +1,16 @@
 package potenday.app.domain;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import potenday.app.api.auth.LogoutTokenRequest;
+import potenday.app.domain.auth.AppUser;
 import potenday.app.domain.auth.TokenProvider;
 import potenday.app.global.error.AuthenticationException;
 import potenday.app.global.error.ErrorCode;
 
 @Service
+@Slf4j
 public class AppTokenService {
 
     private final TokenProvider tokenProvider;
@@ -31,4 +35,27 @@ public class AppTokenService {
       return tokenProvider.issueAccessTokenFromRefreshToken(refreshToken);
     }
 
+  public void removeRefreshToken(AppUser appUser, LogoutTokenRequest logoutTokenRequest) {
+    if (appUser.id() != tokenProvider.parseUserId(logoutTokenRequest.getRefreshToken())) {
+      throw new AuthenticationException(ErrorCode.A003);
+    }
+
+    Boolean hasKey = redisTemplate.hasKey(logoutTokenRequest.getRefreshToken());
+    if (hasKey == null || !hasKey) {
+      log.info("not found refresh token : {}", logoutTokenRequest.getRefreshToken());
+      return;
+    }
+
+    boolean validToken = tokenProvider.isValidToken(logoutTokenRequest.getRefreshToken());
+    if (!validToken) {
+      log.error("requested refresh token is expired: {}", logoutTokenRequest.getRefreshToken());
+      return;
+    }
+
+    Boolean deleted = redisTemplate.delete(logoutTokenRequest.getRefreshToken());
+    if (deleted == null || !deleted) {
+      // not throw exception
+      log.error("refresh token not delete: {}", logoutTokenRequest.getRefreshToken());
+    }
+  }
 }

--- a/src/main/java/potenday/app/global/error/ErrorCode.java
+++ b/src/main/java/potenday/app/global/error/ErrorCode.java
@@ -17,11 +17,12 @@ public enum ErrorCode {
   U005("U005", "한글과 영문 문자만 허용됩니다.", HttpStatus.BAD_REQUEST),
   U006("U006", "존재하지 않는 유저입니다.", HttpStatus.NOT_FOUND),
 
-  // 로그인
+  // 로그인, 로그아웃
   L001("L001","지원하지 않는 OAuth Provider", HttpStatus.BAD_REQUEST),
   L002("L002", "내부 사용자 정보를 가져오는 데 문제가 발생하였습니다. ", HttpStatus.INTERNAL_SERVER_ERROR),
   L003("L003", "code 는 필수입니다.", HttpStatus.BAD_REQUEST),
   L004("L004", "redirectUri 는 필수입니다. ", HttpStatus.BAD_REQUEST),
+  L005("L005","refreeshToken 는 필수입니다. ", HttpStatus.BAD_REQUEST),
 
   // 컨텐츠
   C001("C001", "존재하지 않는 고양이 성격입니다.", HttpStatus.BAD_REQUEST),

--- a/src/test/java/potenday/app/acceptance/auth/AuthAcceptanceTest.java
+++ b/src/test/java/potenday/app/acceptance/auth/AuthAcceptanceTest.java
@@ -1,15 +1,27 @@
 package potenday.app.acceptance.auth;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.Matchers.is;
 
 import io.restassured.http.ContentType;
+import java.time.Duration;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import potenday.app.acceptance.AcceptanceTest;
+import potenday.app.domain.auth.TokenProvider;
 
 @DisplayName("인증 인수테스트")
 public class AuthAcceptanceTest extends AcceptanceTest {
+
+  @Autowired
+  StringRedisTemplate redisTemplate;
+
+  @Autowired
+  TokenProvider tokenProvider;
 
   @Test
   @DisplayName("OAuth 로그인 URI 요청 - 성공")
@@ -31,5 +43,69 @@ public class AuthAcceptanceTest extends AcceptanceTest {
       .assertThat().body("result", is("SUCCESS"))
       .assertThat().body("data.provider", is("KAKAO"))
       .assertThat().body("data.oauthUri", is("https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=client-id-sample&redirect_uri=http://localhost:3000"));
+  }
+
+  @Test
+  @DisplayName("로그아웃 요청 - 성공")
+  void logoutSuccessTest() {
+    // given
+    final String refreshToken = tokenProvider.issueAccessToken(1L);
+    saveToken(refreshToken);
+    given()
+          .log()
+          .all()
+          .contentType(ContentType.JSON)
+
+    // when
+    .when()
+      .header("Authorization", String.format("Bearer %s", userToken(1L)))
+      .body(String.format("""
+        {
+          "refreshToken": "%s"
+        }
+        """, refreshToken))
+      .post("/auth/logout")
+
+    // then
+    .then()
+      .log().all()
+      .assertThat().statusCode(200)
+      .assertThat().body("result", is("SUCCESS"));
+  }
+
+  @Test
+  @DisplayName("다른 유저의 refreshToken 로그아웃 요청 시 예외 발생 - 실패")
+  void logoutFailAnotherUserRefreshTokenTest() {
+    // given
+    final String refreshToken = tokenProvider.issueAccessToken(1L);
+    saveToken(refreshToken);
+    given()
+              .log()
+              .all()
+              .contentType(ContentType.JSON)
+
+        // when
+        .when()
+          .header("Authorization", String.format("Bearer %s", userToken(2L)))
+          .body(String.format("""
+          {
+            "refreshToken": "%s"
+          }
+          """, refreshToken))
+          .post("/auth/logout")
+
+        // then
+        .then()
+          .log().all()
+          .assertThat().statusCode(401)
+          .assertThat().body("result", is("ERROR"));
+  }
+
+  private void saveToken(String refreshToken) {
+    redisTemplate.opsForValue().set(refreshToken, "1", Duration.ofSeconds(1000L));
+  }
+
+  private String userToken(long id) {
+    return tokenProvider.issueAccessToken(id);
   }
 }


### PR DESCRIPTION
## 어떤 PR 인가요 ? 🔍

* Jira Ticket : https://it-that-cat.atlassian.net/browse/ITC2W-118

## 변경사항 📝

* 로그아웃 기능 추가
* 사용자 경험을 위해 만료된 refreshToken 이 들어와도 성공응답 반환 -> TTL 시간 = refreshToken 생존시간, 따라서 redis 에서 refreshToken 을 찾아서 삭제하는 로직 진행하지 않음.
* 단, 인증헤더에 있는 accessToken 과 요청 값으로 들어오는 refreshToken 을 비교하여 같은 유저 인지 확인하는 절차를 거침

## Test ScreenShot ✅
<img width="420" alt="스크린샷 2024-07-08 오후 7 16 47" src="https://github.com/401-potenday/backend/assets/43781484/77be21e3-25de-4366-ad60-f86e8e3e938b">