### PR TITLE
🐛 [#56] Bugfix: Auth 로그아웃 인수 테스트 시 Embedded Redis 설정 안해서 테스트 깨진 버그 해결

### DIFF
--- a/src/test/java/potenday/app/acceptance/auth/AuthAcceptanceTest.java
+++ b/src/test/java/potenday/app/acceptance/auth/AuthAcceptanceTest.java
@@ -10,11 +10,14 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import potenday.app.EmbeddedRedisConfig;
 import potenday.app.acceptance.AcceptanceTest;
 import potenday.app.domain.auth.TokenProvider;
 
 @DisplayName("인증 인수테스트")
+@Import(EmbeddedRedisConfig.class)
 public class AuthAcceptanceTest extends AcceptanceTest {
 
   @Autowired


### PR DESCRIPTION
## 어떤 PR 인가요 ? 🔍

* 기타 관련 문서 : #56 

## 변경사항 📝
<img width="481" alt="스크린샷 2024-07-08 오후 7 37 24" src="https://github.com/401-potenday/backend/assets/43781484/eaebd7fc-0a84-4f9d-aafa-a4ebfd5e53d7">

* 인증 테스트시 임베디드 레디스로 테스트 진행할 수 있도록 설정

## Other Information
* 로컬에서 테스트 할 때, docker 로 redis 가 실제로 띄워져 있어서 인지하지 못했음..
* embeded 설정 없어도 -> 실제 docker redis 로 연결되었기 때문에 테스트 통과했었음